### PR TITLE
Updates to allow tap-carvel-workshop to run on the Workshop as a Service environment

### DIFF
--- a/.github/workflows/ghcr-publish.yaml
+++ b/.github/workflows/ghcr-publish.yaml
@@ -1,0 +1,41 @@
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: [ main ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-ARG IMAGE_REPOSITORY=quay.io/eduk8s
-
 FROM registry.tanzu.vmware.com/tanzu-application-platform/tap-packages@sha256:a8870aa60b45495d298df5b65c69b3d7972608da4367bd6e69d6e392ac969dd4
+ARG PIVNET_TOKEN
 
 # All the direct Downloads need to run as root as they are going to /usr/local/bin
 USER root
@@ -10,11 +9,15 @@ RUN curl -L -o /usr/local/bin/pivnet https://github.com/pivotal-cf/pivnet-cli/re
     chmod 755 /usr/local/bin/pivnet
 
 # Tanzu CLI
-COPY tanzu-framework-linux-amd64.tar /tmp
-RUN export TANZU_CLI_NO_INIT=true
-RUN cd /tmp && tar -xvf "tanzu-framework-linux-amd64.tar" -C /tmp && \ 
+RUN pivnet login --api-token=$PIVNET_TOKEN
+RUN pivnet download-product-files --product-slug='tanzu-application-platform' --release-version='1.1.1' --product-file-id=1212839 -d=/tmp && \
+    pivnet logout && \
+    export TANZU_CLI_NO_INIT=true && \
+    cd /tmp && tar -xvf "tanzu-framework-linux-amd64.tar" -C /tmp && \ 
     sudo install "cli/core/v0.11.4/tanzu-core-linux_amd64" /usr/local/bin/tanzu && \ 
-    tanzu plugin install --local cli all
+    tanzu plugin install --local cli all && \
+    rm /tmp/tanzu-framework-linux-amd64.tar && \
+    rm -rf /tmp/cli
 
 RUN curl -L -o /usr/local/bin/kctrl https://github.com/vmware-tanzu/carvel-kapp-controller/releases/download/v0.36.1/kctrl-linux-amd64 && \
     chmod 755 /usr/local/bin/kctrl
@@ -51,4 +54,3 @@ RUN rm -rf /tmp/*
 USER 1001
 COPY --chown=1001:0 . /home/eduk8s/
 RUN fix-permissions /home/eduk8s
-RUN rm /home/eduk8s/tanzu-framework-linux-amd64.tar

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN curl -L -o /usr/local/bin/pivnet https://github.com/pivotal-cf/pivnet-cli/re
 COPY tanzu-framework-linux-amd64.tar /tmp
 RUN export TANZU_CLI_NO_INIT=true
 RUN cd /tmp && tar -xvf "tanzu-framework-linux-amd64.tar" -C /tmp && \ 
-    sudo install "cli/core/v0.11.2/tanzu-core-linux_amd64" /usr/local/bin/tanzu && \ 
+    sudo install "cli/core/v0.11.4/tanzu-core-linux_amd64" /usr/local/bin/tanzu && \ 
     tanzu plugin install --local cli all
 
 RUN curl -L -o /usr/local/bin/kctrl https://github.com/vmware-tanzu/carvel-kapp-controller/releases/download/v0.36.1/kctrl-linux-amd64 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,6 @@ RUN chmod 775 -R $HOME/.krew
 RUN apt update
 RUN apt install ruby-full -y
 
-RUN rm -rf /tmp/*
-
 USER 1001
 COPY --chown=1001:0 . /home/eduk8s/
 RUN fix-permissions /home/eduk8s

--- a/resources/workshop.yaml
+++ b/resources/workshop.yaml
@@ -28,6 +28,8 @@ spec:
       docker:
         enabled: true
         storage: 1Gi
+      registry:
+        enabled: true
     env: 
     - name: TAP_PRODUCT_DOCS_BASE_URL
       value: #@ data.values.tap_product_docs_base_url

--- a/resources/workshop.yaml
+++ b/resources/workshop.yaml
@@ -31,11 +31,11 @@ spec:
     env: 
     - name: TAP_PRODUCT_DOCS_BASE_URL
       value: #@ data.values.tap_product_docs_base_url
-    - name: CONTAINER_REGISTRY_HOSTNAME
+    - name: REGISTRY_HOST
       value: #@ data.values.container_registry.hostname
-    - name: CONTAINER_REGISTRY_USERNAME
+    - name: REGISTRY_USERNAME
       value: #@ data.values.container_registry.username
-    - name: CONTAINER_REGISTRY_PASSWORD
+    - name: REGISTRY_PASSWORD
       value: #@ data.values.container_registry.password  
     objects:
     - apiVersion: rbac.authorization.k8s.io/v1

--- a/workshop/content/exercises/Cluster-Essentials.md
+++ b/workshop/content/exercises/Cluster-Essentials.md
@@ -91,7 +91,7 @@ Because kapp- and secretgen-controller are already installed in this cluster, yo
 
 Let's now check that the Pods of the kapp-controller, and secretgen-controlle are running in our cluster.
 ```execute 
-kubectl get pods -n {{ENV_KAPP_CONTROLLER_NAMESPACE}}} && kubectl get pods -n secretgen-controller
+kubectl get pods -n {{ENV_KAPP_CONTROLLER_NAMESPACE}} && kubectl get pods -n secretgen-controller
 ```
 
 With both running, you can now have a closer look at them after you cleaned up the directory.

--- a/workshop/content/exercises/Cluster-Essentials.md
+++ b/workshop/content/exercises/Cluster-Essentials.md
@@ -91,7 +91,7 @@ Because kapp- and secretgen-controller are already installed in this cluster, yo
 
 Let's now check that the Pods of the kapp-controller, and secretgen-controlle are running in our cluster.
 ```execute 
-kubectl get pods -n kapp-controller && kubectl get pods -n secretgen-controller
+kubectl get pods -n {{ENV_KAPP_CONTROLLER_NAMESPACE}}} && kubectl get pods -n secretgen-controller
 ```
 
 With both running, you can now have a closer look at them after you cleaned up the directory.

--- a/workshop/content/exercises/Kbld-imgpkg-vendir.md
+++ b/workshop/content/exercises/Kbld-imgpkg-vendir.md
@@ -140,18 +140,18 @@ file: carvel-imgpkg/examples/basic-step-1/.imgpkg/bundle.yml
 ###### Pushing the bundle to a registry
 Let's now authenticate with our registry and push the bundle to it registry.
 ```terminal:execute
-command: docker login $CONTAINER_REGISTRY_HOSTNAME -u $CONTAINER_REGISTRY_USERNAME -p $CONTAINER_REGISTRY_PASSWORD
+command: docker login $REGISTRY_HOST -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD
 clear: true
 ```
 ```terminal:execute
-command: imgpkg push -b ${CONTAINER_REGISTRY_HOSTNAME}/tap-carvel-workshop-examples/simple-app-bundle:v1.0.0 -f carvel-imgpkg/examples/basic-step-1
+command: imgpkg push -b ${REGISTRY_HOST}/tap-carvel-workshop-examples/simple-app-bundle:v1.0.0 -f carvel-imgpkg/examples/basic-step-1
 clear: true
 ```
 
 ###### Pulling the bundle from registry
 Now that you have pushed a bundle to a registry, other users can pull it.
 ```terminal:execute
-command: imgpkg pull -b ${CONTAINER_REGISTRY_HOSTNAME}/tap-carvel-workshop-examples/simple-app-bundle:v1.0.0 -o simple-app-bundle
+command: imgpkg pull -b ${REGISTRY_HOST}/tap-carvel-workshop-examples/simple-app-bundle:v1.0.0 -o simple-app-bundle
 clear: true
 ```
 
@@ -173,18 +173,18 @@ clear: true
 ###### Copy a bundle between registries
 To ensure that your Kubernetes application does not rely on images from external registries when deployed or that all images are consolidated into a single registry, even if that registry is not air-gapped, you can use the **imgpkg copy** command to copy a bundle between registries.
 ```terminal:execute
-command: imgpkg copy -b ${CONTAINER_REGISTRY_HOSTNAME}/tap-carvel-workshop-examples/simple-app-bundle:v1.0.0 --to-repo ${CONTAINER_REGISTRY_HOSTNAME}/tap-carvel-workshop-examples/copied-simple-app-bundle
+command: imgpkg copy -b ${REGISTRY_HOST}/tap-carvel-workshop-examples/simple-app-bundle:v1.0.0 --to-repo ${REGISTRY_HOST}/tap-carvel-workshop-examples/copied-simple-app-bundle
 clear: true
 ```
 If you don't have location from which you are able to connect to both registries, there is an option to export/import a tarball.
 ```execute
-imgpkg copy -b ${CONTAINER_REGISTRY_HOSTNAME}/tap-carvel-workshop-examples/simple-app-bundle:v1.0.0 --to-tar my-image.tar
-imgpkg copy --tar my-image.tar --to-repo ${CONTAINER_REGISTRY_HOSTNAME}/tap-carvel-workshop-examples/copied-simple-app-tar-bundle
+imgpkg copy -b ${REGISTRY_HOST}/tap-carvel-workshop-examples/simple-app-bundle:v1.0.0 --to-tar my-image.tar
+imgpkg copy --tar my-image.tar --to-repo ${REGISTRY_HOST}/tap-carvel-workshop-examples/copied-simple-app-tar-bundle
 ```
 
 If you pull the bundle from the destination registry, you should be able to see that the .imgpkg/images.yml file was updated with the destination registry locations of the images. This happened because, in the prior step, the images referenced by the bundle were copied into the destination registry.
 ```terminal:execute
-command: imgpkg pull -b ${CONTAINER_REGISTRY_HOSTNAME}/tap-carvel-workshop-examples/copied-simple-app-tar-bundle:v1.0.0 -o copied-simple-app-tar-bundle
+command: imgpkg pull -b ${REGISTRY_HOST}/tap-carvel-workshop-examples/copied-simple-app-tar-bundle:v1.0.0 -o copied-simple-app-tar-bundle
 clear: true
 ```
 

--- a/workshop/content/exercises/Prepare-Install.md
+++ b/workshop/content/exercises/Prepare-Install.md
@@ -89,20 +89,20 @@ command: tanzu package installed get tap -n tap-install
 clear: true
 ```
 ```terminal:execute
-command: kubectl describe packageinstalls tap -n tap-install
+command: kubectl describe packageinstalls {{ ENV_TAP_PACKAGE_NAME }} -n tap-install
 clear: true
 ```
 With the eksporter krew plugin, it's easier to have a look at the spec, which references the Package CR, specifies a service account that will be used to install underlying package contents, and references a secret that includes values to be included in package's templating step.
 ```terminal:execute
-command: kubectl eksporter packageinstalls tap -n tap-install
+command: kubectl eksporter packageinstalls {{ ENV_TAP_PACKAGE_NAME }} -n tap-install
 clear: true
 ```
 
-You can also view the App CR created as a result of the PackageInstall creation via `kubectl tree packageinstalls tap -n tap-install` if you have the privileges.
+You can also view the App CR created as a result of the PackageInstall creation via `kubectl tree packageinstalls {{ ENV_TAP_PACKAGE_NAME }} -n tap-install` if you have the privileges.
 
 And can have a closer look with.
 ```terminal:execute
-command: kubectl describe app tap -n tap-install
+command: kubectl describe app {{ ENV_TAP_PACKAGE_NAME }} -n tap-install
 clear: true
 ```
 

--- a/workshop/content/exercises/Prepare-Install.md
+++ b/workshop/content/exercises/Prepare-Install.md
@@ -85,7 +85,7 @@ With the current version of TAP it's **not possible to exclude tap-telemetry.tan
 
 To get details for a package, e.g. the `USEFUL-ERROR-MESSAGE`, you can use the following commands.
 ```terminal:execute
-command: tanzu package installed get tap -n tap-install
+command: tanzu package installed get {{ ENV_TAP_PACKAGE_NAME }} -n tap-install
 clear: true
 ```
 ```terminal:execute

--- a/workshop/modules.yaml
+++ b/workshop/modules.yaml
@@ -32,3 +32,7 @@ modules:
     workshop-summary:
         name: Workshop Summary
         exit_sign: Finish Workshop
+config:
+    vars:
+    - name: KAPP_CONTROLLER_NAMESPACE
+      value: kapp-controller

--- a/workshop/modules.yaml
+++ b/workshop/modules.yaml
@@ -36,3 +36,5 @@ config:
     vars:
     - name: KAPP_CONTROLLER_NAMESPACE
       value: kapp-controller
+    - name: TAP_PACKAGE_NAME
+      value: tap


### PR DESCRIPTION
This set of changes includes

- Enhancement to the container image build to shink it down in size
- Rename of registry parameters to allow the workshop to be easily be used with the embedded workshop session registry of Learning Center
- Addition of an optional workshop environment variable "KAPP_CONTROLLER_NAMESPACE" to change the namespace used for kapp-controller in the instructions (defaults to "kapp-controller")
- Addition of an optional workshop environment variable "TAP_PACKAGE_NAME" to change the PackageInstall name for TAP used in the instructions (defaults to "tap")